### PR TITLE
[ISSUE #27] Allow us to choose when the req-shield is triggered (creation or modification of the cache)

### DIFF
--- a/core-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/kotlin/coroutine/config/ReqShieldConfiguration.kt
+++ b/core-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/kotlin/coroutine/config/ReqShieldConfiguration.kt
@@ -40,6 +40,7 @@ data class ReqShieldConfiguration<T>(
             KeyGlobalLock(globalLockFunction!!, globalUnLockFunction!!, lockTimeoutMillis)
         },
     val maxAttemptGetCache: Int = MAX_ATTEMPT_GET_CACHE,
+    val reqShieldWorkMode: ReqShieldWorkMode = ReqShieldWorkMode.CREATE_AND_UPDATE_CACHE,
 ) {
     init {
         if (!isLocalLock) {
@@ -51,4 +52,10 @@ data class ReqShieldConfiguration<T>(
             }
         }
     }
+}
+
+enum class ReqShieldWorkMode {
+    CREATE_AND_UPDATE_CACHE,
+    ONLY_CREATE_CACHE,
+    ONLY_UPDATE_CACHE,
 }

--- a/core-reactor/src/main/kotlin/com/linecorp/cse/reqshield/reactor/config/ReqShieldConfiguration.kt
+++ b/core-reactor/src/main/kotlin/com/linecorp/cse/reqshield/reactor/config/ReqShieldConfiguration.kt
@@ -44,6 +44,7 @@ data class ReqShieldConfiguration<T>(
             KeyGlobalLock(globalLockFunction!!, globalUnLockFunction!!, lockTimeoutMillis)
         },
     val maxAttemptGetCache: Int = MAX_ATTEMPT_GET_CACHE,
+    val reqShieldWorkMode: ReqShieldWorkMode = ReqShieldWorkMode.CREATE_AND_UPDATE_CACHE,
 ) {
     init {
         if (!isLocalLock) {
@@ -55,4 +56,10 @@ data class ReqShieldConfiguration<T>(
             }
         }
     }
+}
+
+enum class ReqShieldWorkMode {
+    CREATE_AND_UPDATE_CACHE,
+    ONLY_CREATE_CACHE,
+    ONLY_UPDATE_CACHE,
 }

--- a/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/annotation/ReqShieldCacheable.kt
+++ b/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/annotation/ReqShieldCacheable.kt
@@ -16,6 +16,7 @@
 
 package com.linecorp.cse.reqshield.spring.webflux.kotlin.coroutine.annotation
 
+import com.linecorp.cse.reqshield.kotlin.coroutine.config.ReqShieldWorkMode
 import com.linecorp.cse.reqshield.support.constant.ConfigValues.MAX_ATTEMPT_GET_CACHE
 import java.lang.annotation.Inherited
 
@@ -30,4 +31,5 @@ annotation class ReqShieldCacheable(
     val decisionForUpdate: Int = 90,
     val maxAttemptGetCache: Int = MAX_ATTEMPT_GET_CACHE,
     val timeToLiveMillis: Long = 10 * 60 * 1000,
+    val reqShieldWorkMode: ReqShieldWorkMode = ReqShieldWorkMode.CREATE_AND_UPDATE_CACHE,
 )

--- a/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/aspect/ReqShieldAspect.kt
+++ b/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/aspect/ReqShieldAspect.kt
@@ -142,6 +142,7 @@ class ReqShieldAspect<T>(
                 lockTimeoutMillis = annotation.lockTimeoutMillis,
                 decisionForUpdate = annotation.decisionForUpdate,
                 maxAttemptGetCache = annotation.maxAttemptGetCache,
+                reqShieldWorkMode = annotation.reqShieldWorkMode,
             )
 
         return ReqShield(reqShieldConfiguration)

--- a/core-spring-webflux/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/annotation/ReqShieldCacheable.kt
+++ b/core-spring-webflux/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/annotation/ReqShieldCacheable.kt
@@ -16,6 +16,7 @@
 
 package com.linecorp.cse.reqshield.spring.webflux.annotation
 
+import com.linecorp.cse.reqshield.reactor.config.ReqShieldWorkMode
 import com.linecorp.cse.reqshield.support.constant.ConfigValues.MAX_ATTEMPT_GET_CACHE
 import java.lang.annotation.Inherited
 
@@ -30,4 +31,5 @@ annotation class ReqShieldCacheable(
     val decisionForUpdate: Int = 90,
     val maxAttemptGetCache: Int = MAX_ATTEMPT_GET_CACHE,
     val timeToLiveMillis: Long = 10 * 60 * 1000,
+    val reqShieldWorkMode: ReqShieldWorkMode = ReqShieldWorkMode.CREATE_AND_UPDATE_CACHE,
 )

--- a/core-spring-webflux/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/aspect/ReqShieldAspect.kt
+++ b/core-spring-webflux/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/aspect/ReqShieldAspect.kt
@@ -128,6 +128,7 @@ class ReqShieldAspect<T>(
                 lockTimeoutMillis = annotation.lockTimeoutMillis,
                 decisionForUpdate = annotation.decisionForUpdate,
                 maxAttemptGetCache = annotation.maxAttemptGetCache,
+                reqShieldWorkMode = annotation.reqShieldWorkMode,
             )
 
         return ReqShield(reqShieldConfiguration)

--- a/core-spring/src/main/kotlin/com/linecorp/cse/reqshield/spring/annotation/ReqShieldCacheable.kt
+++ b/core-spring/src/main/kotlin/com/linecorp/cse/reqshield/spring/annotation/ReqShieldCacheable.kt
@@ -16,6 +16,7 @@
 
 package com.linecorp.cse.reqshield.spring.annotation
 
+import com.linecorp.cse.reqshield.config.ReqShieldWorkMode
 import com.linecorp.cse.reqshield.support.constant.ConfigValues.MAX_ATTEMPT_GET_CACHE
 import java.lang.annotation.Inherited
 
@@ -30,4 +31,5 @@ annotation class ReqShieldCacheable(
     val decisionForUpdate: Int = 90,
     val maxAttemptGetCache: Int = MAX_ATTEMPT_GET_CACHE,
     val timeToLiveMillis: Long = 10 * 60 * 1000,
+    val reqShieldWorkMode: ReqShieldWorkMode = ReqShieldWorkMode.CREATE_AND_UPDATE_CACHE,
 )

--- a/core-spring/src/main/kotlin/com/linecorp/cse/reqshield/spring/aspect/ReqShieldAspect.kt
+++ b/core-spring/src/main/kotlin/com/linecorp/cse/reqshield/spring/aspect/ReqShieldAspect.kt
@@ -88,6 +88,7 @@ class ReqShieldAspect<T>(
                 lockTimeoutMillis = annotation.lockTimeoutMillis,
                 decisionForUpdate = annotation.decisionForUpdate,
                 maxAttemptGetCache = annotation.maxAttemptGetCache,
+                reqShieldWorkMode = annotation.reqShieldWorkMode,
             )
 
         return ReqShield(reqShieldConfiguration)

--- a/core/src/main/kotlin/com/linecorp/cse/reqshield/config/ReqShieldConfiguration.kt
+++ b/core/src/main/kotlin/com/linecorp/cse/reqshield/config/ReqShieldConfiguration.kt
@@ -46,6 +46,7 @@ data class ReqShieldConfiguration<T>(
             KeyGlobalLock(globalLockFunction!!, globalUnLockFunction!!, lockTimeoutMillis)
         },
     val maxAttemptGetCache: Int = MAX_ATTEMPT_GET_CACHE,
+    val reqShieldWorkMode: ReqShieldWorkMode = ReqShieldWorkMode.CREATE_AND_UPDATE_CACHE,
 ) {
     init {
         if (!isLocalLock) {
@@ -57,4 +58,10 @@ data class ReqShieldConfiguration<T>(
             }
         }
     }
+}
+
+enum class ReqShieldWorkMode {
+    CREATE_AND_UPDATE_CACHE,
+    ONLY_CREATE_CACHE,
+    ONLY_UPDATE_CACHE,
 }

--- a/req-shield-spring-example/src/main/kotlin/com/linecorp/cse/reqshield/service/SampleService.kt
+++ b/req-shield-spring-example/src/main/kotlin/com/linecorp/cse/reqshield/service/SampleService.kt
@@ -16,6 +16,7 @@
 
 package com.linecorp.cse.reqshield.service
 
+import com.linecorp.cse.reqshield.config.ReqShieldWorkMode
 import com.linecorp.cse.reqshield.dto.Product
 import com.linecorp.cse.reqshield.spring.annotation.ReqShieldCacheEvict
 import com.linecorp.cse.reqshield.spring.annotation.ReqShieldCacheable
@@ -32,6 +33,20 @@ class SampleService {
     @ReqShieldCacheable(cacheName = "product", decisionForUpdate = 90, timeToLiveMillis = 60 * 1000)
     fun getProduct(productId: String): Product {
         log.info("find product with db request - req-shield local lock (will take 1 second)")
+        Thread.sleep(500)
+
+        atomicInteger.incrementAndGet()
+        return Product(productId, "product_$productId")
+    }
+
+    @ReqShieldCacheable(
+        cacheName = "productOnlyUpdateCache",
+        decisionForUpdate = 90,
+        timeToLiveMillis = 60 * 1000,
+        reqShieldWorkMode = ReqShieldWorkMode.ONLY_UPDATE_CACHE,
+    )
+    fun getProductOnlyUpdateCache(productId: String): Product {
+        log.info("find product with db request - req-shield local lock only update cache (will take 1 second)")
         Thread.sleep(500)
 
         atomicInteger.incrementAndGet()

--- a/req-shield-spring-example/src/test/kotlin/com/linecorp/cse/reqshield/spring/service/CacheAnnotationTest.kt
+++ b/req-shield-spring-example/src/test/kotlin/com/linecorp/cse/reqshield/spring/service/CacheAnnotationTest.kt
@@ -71,6 +71,26 @@ class CacheAnnotationTest : AbstractRedisTest() {
     }
 
     @Test
+    fun `ReqShieldCacheable test - request to 'sampleService' should be request count times (only update cache mode)`() {
+        val executorService = Executors.newFixedThreadPool(100)
+
+        val testProductId: String = UUID.randomUUID().toString()
+
+        for (i in 1..100) {
+            executorService.submit {
+                sampleService.getProductOnlyUpdateCache(testProductId)
+            }
+        }
+
+        executorService.shutdown()
+        executorService.awaitTermination(3000, TimeUnit.SECONDS)
+
+        await().atMost(Duration.ofMillis(BaseReqShieldTest.AWAIT_TIMEOUT)).untilAsserted {
+            assertEquals(100, sampleService.getRequestCount())
+        }
+    }
+
+    @Test
     fun `ReqShieldCacheable test - request to 'sampleService' should be only one times for global lock`() {
         val executorService = Executors.newFixedThreadPool(100)
 

--- a/req-shield-spring-webflux-example/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/example/service/SampleService.kt
+++ b/req-shield-spring-webflux-example/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/example/service/SampleService.kt
@@ -17,6 +17,7 @@
 package com.linecorp.cse.reqshield.spring.webflux.example.service
 
 import com.linecorp.cse.reqshield.reactor.ReqShield
+import com.linecorp.cse.reqshield.reactor.config.ReqShieldWorkMode
 import com.linecorp.cse.reqshield.spring.webflux.annotation.ReqShieldCacheEvict
 import com.linecorp.cse.reqshield.spring.webflux.annotation.ReqShieldCacheable
 import com.linecorp.cse.reqshield.spring.webflux.example.dto.Product
@@ -36,6 +37,23 @@ class SampleService(
 
     @ReqShieldCacheable(cacheName = "product", decisionForUpdate = 80, timeToLiveMillis = 60 * 1000)
     fun getProduct(productId: String): Mono<Product> =
+        Mono
+            .delay(Duration.ofMillis(500))
+            .then(
+                Mono
+                    .just(Product(productId, "product_$productId"))
+                    .doOnNext {
+                        log.info("find product with db request - req-shield local lock (will take 1 second)")
+                    }.doFinally { atomicInteger.incrementAndGet() },
+            )
+
+    @ReqShieldCacheable(
+        cacheName = "productOnlyUpdataCache",
+        decisionForUpdate = 80,
+        timeToLiveMillis = 60 * 1000,
+        reqShieldWorkMode = ReqShieldWorkMode.ONLY_UPDATE_CACHE,
+    )
+    fun getProductOnlyUpdateCache(productId: String): Mono<Product> =
         Mono
             .delay(Duration.ofMillis(500))
             .then(

--- a/req-shield-spring-webflux-example/src/test/kotlin/com/linecorp/cse/reqshield/spring/webflux/example/service/CacheAnnotationTest.kt
+++ b/req-shield-spring-webflux-example/src/test/kotlin/com/linecorp/cse/reqshield/spring/webflux/example/service/CacheAnnotationTest.kt
@@ -71,6 +71,26 @@ class CacheAnnotationTest : AbstractRedisTest() {
     }
 
     @Test
+    fun `ReqShieldCacheable test - request to 'sampleService' should be request count times(only update cache mode)`() {
+        val testProductId: String = UUID.randomUUID().toString()
+
+        val flux =
+            Flux
+                .range(1, 20)
+                .flatMap {
+                    sampleService
+                        .getProductOnlyUpdateCache(testProductId)
+                        .subscribeOn(Schedulers.boundedElastic())
+                }.collectList()
+
+        StepVerifier
+            .create(flux)
+            .assertNext { productList ->
+                assertEquals(19, sampleService.getRequestCount(), "Request count should be 19")
+            }.verifyComplete()
+    }
+
+    @Test
     fun `ReqShieldCacheable test - request to 'sampleService' should be only one times For Global Lock`() {
         val testProductId: String = UUID.randomUUID().toString()
 

--- a/req-shield-spring-webflux-kotlin-coroutine-example/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/example/service/SampleService.kt
+++ b/req-shield-spring-webflux-kotlin-coroutine-example/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/example/service/SampleService.kt
@@ -17,6 +17,7 @@
 package com.linecorp.cse.reqshield.spring.webflux.kotlin.coroutine.example.service
 
 import com.linecorp.cse.reqshield.kotlin.coroutine.ReqShield
+import com.linecorp.cse.reqshield.kotlin.coroutine.config.ReqShieldWorkMode
 import com.linecorp.cse.reqshield.spring.webflux.kotlin.coroutine.annotation.ReqShieldCacheEvict
 import com.linecorp.cse.reqshield.spring.webflux.kotlin.coroutine.annotation.ReqShieldCacheable
 import com.linecorp.cse.reqshield.spring.webflux.kotlin.coroutine.example.dto.Product
@@ -35,6 +36,21 @@ class SampleService(
 
     @ReqShieldCacheable(cacheName = "product", decisionForUpdate = 80, timeToLiveMillis = 60 * 1000)
     suspend fun getProduct(productId: String): Product {
+        log.info("find product with db request with req-shield local lock (will take 1 second)")
+
+        delay(500)
+        atomicInteger.incrementAndGet()
+
+        return Product(productId, "product_$productId")
+    }
+
+    @ReqShieldCacheable(
+        cacheName = "productOnlyUpdateCache",
+        decisionForUpdate = 80,
+        timeToLiveMillis = 60 * 1000,
+        reqShieldWorkMode = ReqShieldWorkMode.ONLY_UPDATE_CACHE,
+    )
+    suspend fun getProductOnlyUpdateCache(productId: String): Product {
         log.info("find product with db request with req-shield local lock (will take 1 second)")
 
         delay(500)

--- a/req-shield-spring-webflux-kotlin-coroutine-example/src/test/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/example/service/CacheAnnotationTest.kt
+++ b/req-shield-spring-webflux-kotlin-coroutine-example/src/test/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/example/service/CacheAnnotationTest.kt
@@ -67,6 +67,22 @@ class CacheAnnotationTest : AbstractRedisTest() {
         }
 
     @Test
+    fun `ReqShieldCacheable test - request to 'sampleService' should be request count times(only update cache mode)`() =
+        runBlocking {
+            val testProductId: String = UUID.randomUUID().toString()
+
+            List(20) {
+                async {
+                    sampleService.getProductOnlyUpdateCache(testProductId)
+                }
+            }.awaitAll()
+
+            delay(500)
+
+            Assertions.assertEquals(20, sampleService.getRequestCount())
+        }
+
+    @Test
     fun `ReqShieldCacheable test - request to 'sampleService' should be only one times For Global Lock`() =
         runBlocking {
             val testProductId: String = UUID.randomUUID().toString()

--- a/support/src/testFixtures/kotlin/com/linecorp/cse/reqshield/support/BaseReqShieldTest.kt
+++ b/support/src/testFixtures/kotlin/com/linecorp/cse/reqshield/support/BaseReqShieldTest.kt
@@ -19,6 +19,8 @@ package com.linecorp.cse.reqshield.support
 interface BaseReqShieldTest {
     fun testSetMethodCacheNotExistsAndLocalLockAcquired()
 
+    fun testSetMethodCacheNotExistsAndOnlyUpdateCache()
+
     fun testSetMethodCacheNotExistsAndGlobalLockAcquired()
 
     fun testSetMethodCacheNotExistsAndGlobalLockAcquiredAndDoesNotExistGlobalLockFunction()
@@ -42,6 +44,8 @@ interface BaseReqShieldTest {
     fun testSetMethodCacheExistsButNotTargetedForUpdate()
 
     fun testSetMethodCacheExistsAndTheUpdateTarget()
+
+    fun testSetMethodCacheExistsAndTheUpdateTargetOnlyCreateCache()
 
     fun testSetMethodCacheExistsAndTheUpdateTargetAndCallableReturnNull()
 


### PR DESCRIPTION
issue #27 

- Add `ReqshieldWorkMode` settings to `ReqshieldConfiguration`
    - `ReqshieldWorkMode` includes three modes below.
        - CREATE_AND_UPDATE_CACHE (default)
            - When creating cache and when updating, processing using req-shield
        - ONLY_CREATE_CACHE
            - When only creating cache, processing using req-shield
        - ONLY_UPDATE_CACHE
            - When only updating cache, processing using req-shield 
    - Add `reqShieldWorkMode` settings to `ReqShieldCacheable`