### PR TITLE
[ISSUE-26] Feature Request: Dynamically Generating Keys - keyGenerator support

### DIFF
--- a/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/annotation/ReqShieldCacheEvict.kt
+++ b/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/annotation/ReqShieldCacheEvict.kt
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited
 annotation class ReqShieldCacheEvict(
     val cacheName: String,
     val key: String = "",
+    val keyGenerator: String = "",
     val isLocalLock: Boolean = true,
     val lockTimeoutMillis: Long = 3000,
     val condition: String = "",

--- a/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/annotation/ReqShieldCacheable.kt
+++ b/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/annotation/ReqShieldCacheable.kt
@@ -26,6 +26,7 @@ import java.lang.annotation.Inherited
 annotation class ReqShieldCacheable(
     val cacheName: String,
     val key: String = "",
+    val keyGenerator: String = "",
     val isLocalLock: Boolean = true,
     val lockTimeoutMillis: Long = 3000,
     val decisionForUpdate: Int = 90,

--- a/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/aspect/ReqShieldAspect.kt
+++ b/core-spring-webflux-kotlin-coroutine/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/aspect/ReqShieldAspect.kt
@@ -26,6 +26,9 @@ import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.BeanFactoryAware
+import org.springframework.cache.interceptor.KeyGenerator
 import org.springframework.cache.interceptor.SimpleKeyGenerator
 import org.springframework.context.expression.MethodBasedEvaluationContext
 import org.springframework.core.DefaultParameterNameDiscoverer
@@ -36,6 +39,7 @@ import org.springframework.expression.Expression
 import org.springframework.expression.spel.standard.SpelExpressionParser
 import org.springframework.stereotype.Component
 import org.springframework.util.StringUtils
+import org.springframework.util.function.SingletonSupplier
 import reactor.core.publisher.Mono
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
@@ -45,9 +49,13 @@ import kotlin.coroutines.Continuation
 @Component
 class ReqShieldAspect<T>(
     private val asyncCache: AsyncCache<T>,
-) {
+) : BeanFactoryAware {
+    private lateinit var beanFactory: BeanFactory
     private val springVersion = SpringVersion.getVersion()
     private val spelParser = SpelExpressionParser()
+    private var defaultKeyGenerator = SingletonSupplier.of<KeyGenerator> { SimpleKeyGenerator() }
+
+    private val keyGeneratorMap = ConcurrentHashMap<String, KeyGenerator>()
     internal val reqShieldMap = ConcurrentHashMap<String, ReqShield<T>>()
 
     @Around("execution(@com.linecorp.cse.reqshield.spring.webflux.kotlin.coroutine.annotation.* * *(.., kotlin.coroutines.Continuation))")
@@ -92,20 +100,25 @@ class ReqShieldAspect<T>(
 
     fun getCacheEvictAnnotation(joinPoint: ProceedingJoinPoint): ReqShieldCacheEvict =
         AnnotationUtils.getAnnotation(getTargetMethod(joinPoint), ReqShieldCacheEvict::class.java)
-            ?: throw IllegalArgumentException("ReqShieldCacheable annotation is required")
+            ?: throw IllegalArgumentException("ReqShieldCacheEvict annotation is required")
 
     internal fun getCacheableCacheKey(joinPoint: ProceedingJoinPoint): String {
         val annotation = getCacheableAnnotation(joinPoint)
-        return getCacheKeyOrDefault(annotation.key, joinPoint)
+        validateCacheKey(annotation.key, annotation.keyGenerator)
+
+        return getCacheKeyOrDefault(annotation.key, annotation.keyGenerator, joinPoint)
     }
 
     internal fun getCacheEvictCacheKey(joinPoint: ProceedingJoinPoint): String {
         val annotation = getCacheEvictAnnotation(joinPoint)
-        return getCacheKeyOrDefault(annotation.key, joinPoint)
+        validateCacheKey(annotation.key, annotation.keyGenerator)
+
+        return getCacheKeyOrDefault(annotation.key, annotation.keyGenerator, joinPoint)
     }
 
     private fun getCacheKeyOrDefault(
         annotationCacheKey: String,
+        annotationCacheKeyGenerator: String,
         joinPoint: ProceedingJoinPoint,
     ): String {
         val method = getTargetMethod(joinPoint)
@@ -119,17 +132,16 @@ class ReqShieldAspect<T>(
         val context: EvaluationContext =
             MethodBasedEvaluationContext(joinPoint.target, method, args, DefaultParameterNameDiscoverer())
 
-        val key: String? =
+        val key =
             if (StringUtils.hasText(annotationCacheKey)) {
                 val expression: Expression = spelParser.parseExpression(annotationCacheKey)
                 expression.getValue(context, String::class.java)
             } else {
-                SimpleKeyGenerator.generateKey(joinPoint.target, method, args).toString()
+                val keyGenerator = getOrCreateKeyGenerator(annotationCacheKeyGenerator)
+                keyGenerator.generate(joinPoint.target, method, args).toString()
             }
 
-        if (key.isNullOrBlank()) {
-            throw IllegalArgumentException("Null key returned for cache method : $method")
-        }
+        require(!key.isNullOrBlank()) { "Null key returned for cache method : $method" }
 
         return key
     }
@@ -166,6 +178,25 @@ class ReqShieldAspect<T>(
         return ReqShield(reqShieldConfiguration)
     }
 
+    private fun validateCacheKey(
+        cacheKey: String,
+        cacheKeyGenerator: String,
+    ) {
+        if (cacheKey.isNotBlank() && cacheKeyGenerator.isNotBlank()) {
+            throw IllegalArgumentException("The key and keyGenerator attributes are mutually exclusive.")
+        }
+    }
+
+    private fun getOrCreateKeyGenerator(keyGeneratorBeanName: String?): KeyGenerator {
+        if (keyGeneratorBeanName.isNullOrBlank()) {
+            return defaultKeyGenerator.obtain()
+        }
+
+        return keyGeneratorMap.computeIfAbsent(keyGeneratorBeanName) {
+            beanFactory.getBean(it, KeyGenerator::class.java)
+        }
+    }
+
     private fun isCoroutineSupportedSpringVersion(): Boolean {
         val version = springVersion ?: return false
         val parts = version.split(".")
@@ -177,4 +208,8 @@ class ReqShieldAspect<T>(
 
     private fun generateReqShieldKey(joinPoint: ProceedingJoinPoint): String =
         "${getCacheableAnnotation(joinPoint).cacheName}-${getCacheableCacheKey(joinPoint)}"
+
+    override fun setBeanFactory(beanFactory: BeanFactory) {
+        this.beanFactory = beanFactory
+    }
 }

--- a/core-spring-webflux-kotlin-coroutine/src/test/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/aspect/ReqShieldAspectTest.kt
+++ b/core-spring-webflux-kotlin-coroutine/src/test/kotlin/com/linecorp/cse/reqshield/spring/webflux/kotlin/coroutine/aspect/ReqShieldAspectTest.kt
@@ -56,11 +56,6 @@ class ReqShieldAspectTest : BaseReqShieldModuleSupportTest {
     private val targetObject = spyk(TestBean())
     private val argument = mapOf("x" to "paramX", "y" to "paramY")
     private val mockContinuation = mockk<Continuation<Any?>>()
-//    private val kotlinMethod =
-//        TestBean::class.functions.find {
-//            it.name == TestBean::cacheableWithSingleArgument.name && it.parameters.size == 2
-//        }
-//    private val method = kotlinMethod?.javaMethod
 
     private val cacheName = "TestCacheName"
     private val cacheKeyGenerator = "customGenerator"

--- a/core-spring-webflux/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/annotation/ReqShieldCacheEvict.kt
+++ b/core-spring-webflux/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/annotation/ReqShieldCacheEvict.kt
@@ -21,6 +21,7 @@ package com.linecorp.cse.reqshield.spring.webflux.annotation
 annotation class ReqShieldCacheEvict(
     val cacheName: String,
     val key: String = "",
+    val keyGenerator: String = "",
     val isLocalLock: Boolean = true,
     val lockTimeoutMillis: Long = 3000,
     val condition: String = "",

--- a/core-spring-webflux/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/annotation/ReqShieldCacheable.kt
+++ b/core-spring-webflux/src/main/kotlin/com/linecorp/cse/reqshield/spring/webflux/annotation/ReqShieldCacheable.kt
@@ -26,6 +26,7 @@ import java.lang.annotation.Inherited
 annotation class ReqShieldCacheable(
     val cacheName: String,
     val key: String = "",
+    val keyGenerator: String = "",
     val isLocalLock: Boolean = true,
     val lockTimeoutMillis: Long = 3000,
     val decisionForUpdate: Int = 90,

--- a/core-spring/src/main/kotlin/com/linecorp/cse/reqshield/spring/annotation/ReqShieldCacheEvict.kt
+++ b/core-spring/src/main/kotlin/com/linecorp/cse/reqshield/spring/annotation/ReqShieldCacheEvict.kt
@@ -24,6 +24,7 @@ import java.lang.annotation.Inherited
 annotation class ReqShieldCacheEvict(
     val cacheName: String,
     val key: String = "",
+    val keyGenerator: String = "",
     val isLocalLock: Boolean = true,
     val lockTimeoutMillis: Long = 3000,
     val condition: String = "",

--- a/core-spring/src/main/kotlin/com/linecorp/cse/reqshield/spring/annotation/ReqShieldCacheable.kt
+++ b/core-spring/src/main/kotlin/com/linecorp/cse/reqshield/spring/annotation/ReqShieldCacheable.kt
@@ -26,6 +26,7 @@ import java.lang.annotation.Inherited
 annotation class ReqShieldCacheable(
     val cacheName: String,
     val key: String = "",
+    val keyGenerator: String = "",
     val isLocalLock: Boolean = true,
     val lockTimeoutMillis: Long = 30000,
     val decisionForUpdate: Int = 90,

--- a/support/src/testFixtures/kotlin/com/linecorp/cse/reqshield/support/BaseReqShieldModuleSupportTest.kt
+++ b/support/src/testFixtures/kotlin/com/linecorp/cse/reqshield/support/BaseReqShieldModuleSupportTest.kt
@@ -17,13 +17,15 @@
 package com.linecorp.cse.reqshield.support
 
 interface BaseReqShieldModuleSupportTest {
-    fun testAspectOperationVerifyReqShieldAndCacheCreation()
+    fun verifyReqShieldCacheCreation()
 
-    fun testAspectOperationReqShieldObjectShouldBeCreatedOnce()
+    fun reqShieldObjectShouldBeCreatedOnce()
 
-    fun testAspectOperationCacheEviction()
+    fun verifyReqShieldCacheEviction()
 
-    fun testCacheKeyGenerationUseGeneratedKey()
+    fun verifyCacheKeyGenerationWithSpEL()
 
-    fun testCacheKeyGenerationCacheKeyShouldBeSuppliedKey()
+    fun verifyCacheKeyGenerationWithKeyGenerator()
+
+    fun verifyCacheKeyGenerationWithDefaultGenerator()
 }


### PR DESCRIPTION
Issue #26 

* Provide support for customizing keys using keyGenerator, similar to @Cacheable
  * https://docs.spring.io/spring-framework/reference/integration/cache/annotations.html#cache-annotations-cacheable-

Implementation Details (Behaves the same as @Cacheable):
* key (SpEL) and keyGenerator cannot be used at the same time.
* If neither key nor keyGenerator is specified, SimpleKeyGenerator is used.
* If the specified keyGenerator bean is not found, the defaultKeyGenerator is used.
* Once a keyGenerator bean is resolved, it is cached using a ConcurrentHashMap to avoid repeated lookups.